### PR TITLE
Try/Catch for parse errors.

### DIFF
--- a/uglify-js-middleware.js
+++ b/uglify-js-middleware.js
@@ -80,13 +80,17 @@ module.exports = uglify.middleware = function(options) {
         fs.readFile(jsPath, 'utf8', function(err, str) {
           if (err) return error(err);
 
-          var ast = jsp.parse(str);
-          if (mangle) ast = pro.ast_mangle(ast);
-          if (squeeze) ast = pro.ast_squeeze(ast);
-          var ugly = pro.gen_code(ast);
-          fs.writeFile(uglyPath, ugly, 'utf8', function(err) {
-            next(err);
-          });
+          try {
+            var ast = jsp.parse(str);
+            if (mangle) ast = pro.ast_mangle(ast);
+            if (squeeze) ast = pro.ast_squeeze(ast);
+            var ugly = pro.gen_code(ast);
+            fs.writeFile(uglyPath, ugly, 'utf8', function(err) {
+              next(err);
+            });
+          } catch(ex) {
+            return next(ex);
+          }
         });
       }
 


### PR DESCRIPTION
Added a try/catch around the compilation of the target file. Exceptions are then funneled through the normal middleware error chain rather than aborting the entire server process.

I'm a fan of my server not dying. I guess this could be parameterized as an option, but in reality it seems like this is the more normal method of handling errors that occur during processing in middleware.

This came up because I had some not totally correct (read, fully of heinous errors) files that were trying to make it through the uglify minimization steps.
