### PR TITLE
Minor changes to Readme and uglify-js-middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install the library through the Node Package Manager by running
 If you are not already using `uglify`, the `require()` of this library will
 return the middleware function directly.
 
-Once in place, you can now develop pretty source.js code and call source.ugly.js within the html script tag to generate and serve 'uglify'-ed javascript.
+Once in place, you can now develop pretty source.js code and call source.ugly.js within the html script tag to generate and serve 'uglify' -ed javascript.
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ You can install the library through the Node Package Manager by running
     //app setup...
     
     app.use(uglify.middleware({
-      src : __dirname + '/client',
-      dest: __dirname + '/public'
+      src : __dirname + '/public/javascripts',
+      uglyext: 1
     }));
 
 If you are not already using `uglify`, the `require()` of this library will
 return the middleware function directly.
 
+Once in place, you can now develop with your pretty source.js code and call source.ugly.js within the html script tag to generate and serve uglyjs compressed javascript.
 
 Configuration
 -------------
@@ -29,7 +30,7 @@ The following options are supported:
 
  * `src`: Source directory of JavaScript files.
  * `dest`: Destination directory to place uglified files. If omitted, this will
-   default to match `src` and your generated files with be suffixed with
+   default to match `src` and your generated files will be suffixed with
    `.ugly.js` rather than just `.js`.
  * `force`: Boolean indicating whether to force uglification to occur on every
    access.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install the library through the Node Package Manager by running
 If you are not already using `uglify`, the `require()` of this library will
 return the middleware function directly.
 
-Once in place, you can now develop pretty source.js code and call source.ugly.js within the html script tag to generate and serve 'uglify' -ed javascript.
+Once in place, you can now develop pretty source.js code and call source.ugly.js within the html script tag to generate and serve uglify -ed javascript.
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install the library through the Node Package Manager by running
 If you are not already using `uglify`, the `require()` of this library will
 return the middleware function directly.
 
-Once in place, you can now develop with your pretty source.js code and call source.ugly.js within the html script tag to generate and serve uglyjs compressed javascript.
+Once in place, you can now develop pretty source.js code and call source.ugly.js within the html script tag to generate and serve 'uglify'-ed javascript.
 
 Configuration
 -------------

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ You can install the library through the Node Package Manager by running
     
     app.use(uglify.middleware({
       src : __dirname + '/client',
-      dest: __dirname + '/public',
-    });
+      dest: __dirname + '/public'
+    }));
 
 If you are not already using `uglify`, the `require()` of this library will
 return the middleware function directly.

--- a/uglify-js-middleware.js
+++ b/uglify-js-middleware.js
@@ -10,15 +10,9 @@ var jsp = uglify.parser
   , url = require('url')
   , basename = require('path').basename
   , join = require('path').join
-  , ENOENT;
+  , ENOENT = 'ENOENT';
 
 // COMPAT:
-
-try {
-  ENOENT = require('constants').ENOENT;
-} catch (err) {
-  ENOENT = process.ENOENT;
-}
 
 /**
  * Return Connect middleware with the given `options`.
@@ -70,7 +64,7 @@ module.exports = uglify.middleware = function(options) {
 
       // Ignore ENOENT to fall through as 404
       function error(err) {
-        next(ENOENT === err.errno ? null : err);
+        next(ENOENT === err.code ? null : err);
       }
 
       if (force) return compile();
@@ -98,7 +92,7 @@ module.exports = uglify.middleware = function(options) {
         if (err) return error(err);
         fs.stat(uglyPath, function(err, uglyStats) {
           if (err) {
-            if (ENOENT === err.errno) {
+            if (ENOENT === err.code) {
               // JS has not been uglified, compile it!
               compile();
             } else {


### PR DESCRIPTION
On express the error numbers was not pulling in correctly (which meant the .ugly.js files never compiled), so I'm guessing that connect uses different numbers.  I updated to compare the error code and ensure the error was ENOENT.
