### PR TITLE
Updated mkdirp version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 
 	"dependencies": {
 		"uglify-js": "1.2.5",
-		"mkdirp": "0.0.7"
+		"mkdirp": "0.3.5"
 	},
 
 	"repository": {


### PR DESCRIPTION
Tested with 0.3.5 and it works just fine. This prevents the deprecation notice: "path.exists is now called `fs.exists`."
